### PR TITLE
add trailing slashes to links to fix redirecting

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,9 +2,9 @@
   <img src="{{ site.baseurl }}/images/rsslogo.png" alt="RSS logo", align="right", height="90">
   <div class="sidebar-sticky">
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>  
-      <a class="sidebar-nav-item{% if page.url == '/blog' %} active{% endif %}" href="{{ site.baseurl }}/blog">Latest</a>  
-      <a class="sidebar-nav-item" href="http://www.roboticsproceedings.org/">Previous Proceedings</a>  
+      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}/">Home</a>
+      <a class="sidebar-nav-item{% if page.url == '/blog' %} active{% endif %}" href="{{ site.baseurl }}/blog/">Latest</a>
+      <a class="sidebar-nav-item" href="http://www.roboticsproceedings.org/">Previous Proceedings</a>
 
       {% comment %}
         The code below dynamically generates a sidebar nav of pages with

--- a/_information/cfp.md
+++ b/_information/cfp.md
@@ -44,7 +44,7 @@ Grounded language acquisition, Natural language generation, Human-robot dialogue
 
 ## Author Information
 
-Please visit the [author information]({{site.baseurl}}/information/authorinfo) page for extensive instructions.
+Please visit the [author information]({{site.baseurl}}/information/authorinfo/) page for extensive instructions.
 
 ## Special Journal Issues
 

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ sessions, tutorials, and fun! This year, once again, we solicit your best work.
 </p>
 
 <p class="message">
-  Follow the latest {{ site.title }} news <a href="{{site.baseurl}}/blog">here</a>.
+  Follow the latest {{ site.title }} news <a href="{{site.baseurl}}/blog/">here</a>.
 </p>
 
 


### PR DESCRIPTION
Needed to not accidentally re-direct to the github URL. For now, all internal links that are not direct files (i.e. any link like `href="/blog/"`) must end with a trailling slash. I may be able to fix that later, but for now with this fix we can publish the site publicly.
